### PR TITLE
Fix remove Doctrine Error

### DIFF
--- a/src/GoalioRememberMeDoctrineORM/Mapper/RememberMe.php
+++ b/src/GoalioRememberMeDoctrineORM/Mapper/RememberMe.php
@@ -55,14 +55,27 @@ class RememberMe extends GoalioRememberMeMapper
 
     public function removeAll($userId)
     {
-        $er = $this->em->getRepository($this->options->getRememberMeEntityClass());
-        return $er->deleteByUid($userId);
+        $qb = $this->em->createQueryBuilder();
+    	$query = $qb->delete($this->options->getRememberMeEntityClass(), 'rm')
+			->where('rm.user_id = :user_id')
+			->setParameter('user_id', $userId)
+			->getQuery();
+    	return $query->execute();
     }
 
     public function removeSerie($userId, $serieId)
     {
-        $er = $this->em->getRepository($this->options->getRememberMeEntityClass());
-        return $er->deleteByUidAndSid($userId,$serieId);
+        $qb = $this->em->createQueryBuilder();
+    	$query = $qb->delete($this->options->getRememberMeEntityClass(), 'rm')
+			->where('rm.user_id = :user_id')
+			->andWhere('rm.sid = :serie_id')
+			->setParameters(array(
+					'user_id' => $userId,
+					'serie_id' => $serieId
+			))
+			->getQuery();
+			
+		return $query->execute();
     }
 
     public function remove($entity)


### PR DESCRIPTION
In Doctrine, the Entity Manager "delete" function doesn't exist, only "remove" function with an entity in param exist.
The solution is to use the query builder.
